### PR TITLE
fix: set persist-credentials: false in checkout step

### DIFF
--- a/.github/workflows/chromadb-repo-indexer.yml
+++ b/.github/workflows/chromadb-repo-indexer.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Index repository
         id: chromadb-index


### PR DESCRIPTION
Fixes credential persistence security issue. Adds `persist-credentials: false` to the `actions/checkout` step to prevent GitHub tokens from being saved in git config and potentially leaking through artifacts.